### PR TITLE
Fix string comparisons in ber_functions

### DIFF
--- a/qampy/core/ber_functions.py
+++ b/qampy/core/ber_functions.py
@@ -141,28 +141,28 @@ def sync_and_adjust(data_tx, data_rx, adjust="tx"):
     """
     N_tx = data_tx.shape[0]
     N_rx = data_rx.shape[0]
-    assert adjust is "tx" or adjust is "rx", "adjust need to be either 'tx' or 'rx'"
+    assert adjust == "tx" or adjust == "rx", "adjust need to be either 'tx' or 'rx'"
     if N_tx > N_rx:
         offset, rx, ii = find_sequence_offset_complex(data_rx, data_tx)
-        if adjust is "tx":
+        if adjust == "tx":
             tx = np.roll(data_tx, -offset)
             return adjust_data_length(tx, rx, method="truncate")
-        elif adjust is "rx":
+        elif adjust == "rx":
             tx, rx = adjust_data_length(data_tx, rx, method="extend")
             return tx, np.roll(rx, offset)
     elif N_tx < N_rx:
         offset, tx, ii = find_sequence_offset_complex(data_tx, data_rx)
-        if adjust is "tx":
+        if adjust == "tx":
             tx, rx = adjust_data_length(tx, data_rx, method="extend")
             return np.roll(tx, offset), rx
-        elif adjust is "rx":
+        elif adjust == "rx":
             rx = np.roll(data_rx, -offset)
             return adjust_data_length(tx, rx, method="truncate")
     else:
         offset, tx, ii = find_sequence_offset_complex(data_tx, data_rx)
-        if adjust is "tx":
+        if adjust == "tx":
             return np.roll(tx, offset), data_rx
-        elif adjust is "rx":
+        elif adjust == "rx":
             return tx, np.roll(data_rx, -offset)
 
 def sync_rx2tx(data_tx, data_rx, Lsync, imax=200):
@@ -274,14 +274,14 @@ def adjust_data_length(data_tx, data_rx, method=None):
             return data_tx, data_rx
         else:
             return data_tx, data_rx
-    elif method is "truncate":
+    elif method == "truncate":
         if len(data_tx) > len(data_rx):
             return data_tx[:len(data_rx)], data_rx
         elif len(data_tx) < len(data_rx):
             return data_tx, data_rx[:len(data_tx)]
         else:
             return data_tx, data_rx
-    elif method is "extend":
+    elif method == "extend":
         if len(data_tx) > len(data_rx):
             data_rx = _extend_by(data_rx, data_tx.shape[0]-data_rx.shape[0])
             return data_tx, data_rx

--- a/test/test_ber_functions.py
+++ b/test/test_ber_functions.py
@@ -77,9 +77,9 @@ class TestSyncAndAdjust(object):
         N = self.s.shape[1]
         syms = self.s.symbols[0]
         tx, rx = ber_functions.sync_and_adjust(sig[:N1], sig[:N2], adjust=adjust)
-        if N1 is None and adjust is "tx":
+        if N1 is None and adjust == "tx":
             assert (tx.shape[0] == N2) and (rx.shape[0] == N2)
-        elif N2 is None and adjust is "rx":
+        elif N2 is None and adjust == "rx":
             assert (tx.shape[0] == N1) and (rx.shape[0] == N1)
         else:
             assert (tx.shape[0] == N) and (rx.shape[0] == N)


### PR DESCRIPTION
A bunch of the `ber_functions` were failing like this

```
self = <test_ber_functions.TestSyncAndAdjust object at 0x7fabd11bd9e8>, N1 = None, N2 = 1000, adjust = 'tx'

    @pytest.mark.parametrize("N1, N2, adjust", [(None, 1000, "tx"),(None, 1000, "rx" ), (1000, None, "tx"), (1000, None, "rx") ])
    def test_length(self, N1, N2, adjust):
        sig = self.s[0]
        N = self.s.shape[1]
        syms = self.s.symbols[0]
>       tx, rx = ber_functions.sync_and_adjust(sig[:N1], sig[:N2], adjust=adjust)

test_ber_functions.py:79: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

data_tx = SignalQAMGrayCoded([-0.94868330-0.31622777j,  0.94868330-0.9486833j ,
       -0.31622777+0.9486833j , ..., -0.31622777+0.31622777j,
       -0.94868330+0.31622777j, -0.31622777-0.9486833j ])
data_rx = SignalQAMGrayCoded([-0.94868330-0.31622777j,  0.94868330-0.9486833j ,
       -0.31622777+0.9486833j , -0.31622777+0.31...3j ,
        0.31622777+0.9486833j , -0.31622777+0.31622777j,
       -0.94868330-0.9486833j , -0.31622777+0.31622777j]), adjust = 'tx'

    def sync_and_adjust(data_tx, data_rx, adjust="tx"):
        """
        Synchronize and adjust length of received and transmitted data sequence. When the length
        differs between sequences the sequence length will be adjusted based on the adjust parameter
        and the length of the sequences. If the to adjusting sequence is shorter than the other sequence,
        we will assume that the pattern is repetitive and therefore pad the sequence. If it is longer than
        the other sequence we will truncate after adjusting the offset. Note that if sequences are complex we will
        rotate around the complex plane to remove abiguities.
    
        Parameters
        ----------
        data_tx : array_like
            transmitted symbol or bit sequence
        data_rx : array_like
            received symbol sequence can be noisy
        adjust : string, optional
            parameter that determines which data sequence to adjust. If "tx" truncate or extend data_tx
            if "rx" truncate or extend data_rx
    
        Returns
        -------
        tx : array_like
           (possibly adjusted) tx data
        rx : array_like
           (possibly adjusted) rx data
        """
        N_tx = data_tx.shape[0]
        N_rx = data_rx.shape[0]
>       assert adjust is "tx" or adjust is "rx", "adjust need to be either 'tx' or 'rx'"
E       AssertionError: adjust need to be either 'tx' or 'rx'
```

since strings where compared with the `is` operator instead of `==`. I think it is intended to check the content here and not if the identity is equal (which is not).

With this changes, pytest passes on `test_ber_functions.py`.