### PR TITLE
Add possibility of building/installing on  non-x86 and MacOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ requires = [
     "wheel",
     "setuptools",
     "pythran>=0.9.11",
-    "numpy>=0.12"
+    "numpy>=0.12",
+    "matplotlib",
     ]
 
 [project]
@@ -54,6 +55,7 @@ repository = "https://github.com/ChalmersPhotonicsLab/QAMpy"
 
 [project.optional-dependencies]
     test = ["pytest",
+            "pytest-benchmark",
             ]
     docs = ["sphinx"]
 [tool.setuptools.dynamic]

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from os import path
 import sys
 import numpy as np
 from pythran.dist import PythranExtension, PythranBuildExt
+import platform
 
 def read(rel_path):
     here = path.abspath(path.dirname(__file__))
@@ -19,12 +20,20 @@ def get_version(rel_path):
     else:
         raise RuntimeError("Unable to find version string.")
 
-COMPILER_ARGS_PYT = ["-O3", "-ffast-math", "-mfpmath=sse", "-march=native",
+
+COMPILER_ARGS_PYT = ["-O3", "-ffast-math", "-march=native",
                      "-funroll-loops",
                       "-fopenmp", "-std=c++11", "-fno-math-errno", "-w",
                       "-fvisibility=hidden", "-fno-wrapv", "-DUSE_XSIMD",
                      "-DNDEBUG", "-finline-limit=100000"]
-LINK_ARGS = ["-fopenmp", "-lm", "-Wl,-strip-all"]
+# SSE not available on non-x86
+if platform.machine() == "x86_64":
+    COMPILER_ARGS_PYT += ["-mfpmath=sse"]
+
+LINK_ARGS = ["-fopenmp", "-lm"]
+# MacOS Linker does not support stripping symbols
+if platform.system() != "Darwin":
+    LINK_ARGS += ["-Wl,-strip-all"]
 
 WIN_LINK_ARGS = ["/openmp"]
 

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -68,8 +68,6 @@ def test_equalisation_prec(dtype, method, benchmark, backend):
     #S = impairments.apply_phase_noise(S, 100e3)
     S = impairments.change_snr(S, snr)
     SS = impairments.apply_PMD(S, theta, t_pmd)
-    if backend=="pth":
-        method = method+"_pth"
     wxy, err = benchmark(equalisation.equalise_signal, SS, mu, Ntaps=ntaps, method=method, adaptive_stepsize=True, )
     #E = equalisation.apply_filter(SS,  wxy)
     #E = helpers.normalise_and_center(E)

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -5,10 +5,7 @@ import numpy.testing as npt
 import matplotlib.pylab as plt
 from qampy import signals, impairments, equalisation, helpers, phaserec
 from qampy.core import resample
-from qampy.core.equalisation import cython_equalisation
 from qampy.core.equalisation import pythran_equalisation
-from qampy.core.dsp_cython import soft_l_value_demapper as soft_l_value_demapper_pyx
-from qampy.core.dsp_cython import soft_l_value_demapper_minmax as soft_l_value_demapper_minmax_pyx
 from qampy.core.pythran_dsp import soft_l_value_demapper as soft_l_value_demapper_pyt
 from qampy.core.pythran_dsp import soft_l_value_demapper_minmax as soft_l_value_demapper_minmax_pyt
 from qampy.core import equalisation as cequalisation
@@ -23,13 +20,11 @@ def test_resampling_benchmark(arr, taps, fconv, benchmark):
     s = benchmark(resample.rrcos_resample, arr, 1, 3, 1, beta=0.1, taps=taps, fftconv=fconv )
 
 @pytest.mark.parametrize("dtype", [np.complex64, np.complex128])
-@pytest.mark.parametrize("backend", ["pyx", "pyt"])
+@pytest.mark.parametrize("backend", ["pyt"])
 def test_quantize_precision(dtype, benchmark, backend):
     benchmark.group = "quantize"
     s = signals.SignalQAMGrayCoded(128, 2**20, dtype=dtype)
-    if backend == "pyx":
-        o = benchmark(cython_equalisation.make_decision, s[0], s.coded_symbols)
-    elif backend == "pyt":
+    if backend == "pyt":
         o = benchmark(pythran_equalisation.make_decision, s[0], s.coded_symbols)
     npt.assert_array_almost_equal(s.symbols[0], o)
 
@@ -40,7 +35,7 @@ def test_quantize_precision(dtype, benchmark, backend):
     #npt.assert_array_almost_equal(s.symbols[0], o)
 
 @pytest.mark.parametrize("dtype", [np.complex64, np.complex128])
-@pytest.mark.parametrize("method", ["pyx", "py", "af", "pyt"])
+@pytest.mark.parametrize("method", ["py", "af", "pyt"])
 def test_bps(dtype, method, benchmark):
         benchmark.group = "bps"
         angle = np.pi/5.1
@@ -52,7 +47,7 @@ def test_bps(dtype, method, benchmark):
 
 @pytest.mark.parametrize("dtype", [np.complex64, np.complex128])
 @pytest.mark.parametrize("method", ["cma", "mcma", "sbd",  "mddma", "dd" ])
-@pytest.mark.parametrize("backend", ["pyx", "pth"])
+@pytest.mark.parametrize("backend", ["pth"])
 def test_equalisation_prec(dtype, method, benchmark, backend):
     benchmark.group = "equalisation " + method
     fb = 40.e9
@@ -84,7 +79,6 @@ def test_equalisation_prec(dtype, method, benchmark, backend):
 
 @pytest.mark.skip()
 @pytest.mark.parametrize("dtype", [ np.complex64, np.complex128])
-#@pytest.m    npt.assert_allclose(0, ser, atol=3e-5)ark.parametrize("method", [cequalisation.apply_filter, cython_equalisation.apply_filter_signal, cython_equalisation.apply_filter_singal2 ])
 def test_apply_filter(dtype, benchmark):
     fb = 40.e9
     os = 2
@@ -102,7 +96,7 @@ def test_apply_filter(dtype, benchmark):
     S = impairments.change_snr(S, snr)
     SS = impairments.apply_PMD(S, theta, t_pmd)
     wxy, err = equalisation.equalise_signal(SS, mu, Ntaps=ntaps, method="mcma", adaptive_step=True)
-    E1 = equalisation.apply_filter(SS,  wxy, method="pyx")
+    E1 = equalisation.apply_filter(SS,  wxy, method="pyt")
     E2 = equalisation.apply_filter(SS, wxy, method="py")
     E2 = E1.recreate_from_np_array(E2)
     E1 = helpers.normalise_and_center(E1)
@@ -117,7 +111,7 @@ def test_apply_filter(dtype, benchmark):
     npt.assert_allclose(0, ser2, atol=3e-5)
 
 @pytest.mark.parametrize("dtype", [np.complex64, np.complex128])
-@pytest.mark.parametrize("method", ["pyt", "pyx"])
+@pytest.mark.parametrize("method", ["pyt"])
 @pytest.mark.parametrize("type", ["log", "mm"])
 def test_soft_l_values_benchmark(dtype, method, benchmark, type):
     benchmark.group = "soft_l_value"
@@ -131,15 +125,9 @@ def test_soft_l_values_benchmark(dtype, method, benchmark, type):
             benchmark(soft_l_value_demapper_pyt, s[0], int(np.log2(M)), snr, s._bitmap_mtx)
         else:
             benchmark(soft_l_value_demapper_minmax_pyt, s[0], int(np.log2(M)), snr, s._bitmap_mtx)
-    else:
-        if type == "log":
-            benchmark(soft_l_value_demapper_pyx, s[0], M, snr, s._bitmap_mtx)
-        else:
-            benchmark(soft_l_value_demapper_minmax_pyx, s[0], M, snr, s._bitmap_mtx)
-
 
 @pytest.mark.parametrize("dtype", [np.complex64, np.complex128])
-@pytest.mark.parametrize("method", ["py", "pyx", "pth"])
+@pytest.mark.parametrize("method", ["py", "pth"])
 def test_apply_filter_benchmark(dtype, method, benchmark):
     benchmark.group = "apply filter "+str(dtype)
     fb = 40.e9
@@ -164,14 +152,11 @@ def test_apply_filter_benchmark(dtype, method, benchmark):
     npt.assert_allclose(0, ser, atol=3e-5)
 
 @pytest.mark.parametrize("dtype", [np.complex64, np.complex128])
-@pytest.mark.parametrize("method", ["pyt", "pyx"])
+@pytest.mark.parametrize("method", ["pyt"])
 @pytest.mark.parametrize("M", [64, 128, 256])
 def test_select_angles_benchmark(dtype, method, benchmark, M):
     benchmark.group = "select_angle"
-    from qampy.core.dsp_cython import bps
-    if method == "pyx":
-        from qampy.core.dsp_cython import select_angles
-    elif method == "pyt":
+    if method == "pyt":
         from qampy.core.pythran_dsp import select_angles
     fb = 40.e9
     N = 2**17

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -6,6 +6,7 @@ import matplotlib.pylab as plt
 from qampy import signals, impairments, equalisation, helpers, phaserec
 from qampy.core import resample
 from qampy.core.equalisation import pythran_equalisation
+from qampy.core.phaserecovery import _bps_idx_pyt
 from qampy.core.pythran_dsp import soft_l_value_demapper as soft_l_value_demapper_pyt
 from qampy.core.pythran_dsp import soft_l_value_demapper_minmax as soft_l_value_demapper_minmax_pyt
 from qampy.core import equalisation as cequalisation
@@ -163,12 +164,12 @@ def test_select_angles_benchmark(dtype, method, benchmark, M):
     NL = 40
     sig = signals.SignalQAMGrayCoded(M, N, fb=fb, nmodes=1, dtype=dtype)
     sig = impairments.apply_phase_noise(sig, 40e3)
-    if dtype is np.dtype(np.complex64):
+    if dtype is np.complex64:
         fdtype = np.float32
     else:
         fdtype = np.float64
     angles = np.linspace(-np.pi/4, np.pi/4, M, endpoint=False, dtype=fdtype).reshape(1,-1)
-    idx = bps(sig[0], angles, sig.coded_symbols, NL)
+    idx = _bps_idx_pyt(sig[0], angles, sig.coded_symbols, NL)
     ph = np.array(benchmark(select_angles,  angles, idx)).reshape(1, -1)
     ph[:, NL:-NL] = np.unwrap(ph[:, NL:-NL]*4)/4
     sigo = sig*np.exp(1j*ph).astype(sig.dtype)


### PR DESCRIPTION
This change allows installing QAMPy on a MacBook Pro M1 (arm64/Darwin). 
Also I fixed some of the tests due to changed API in separate commits. Still there are quite some tests failing (for some reason or other). 
